### PR TITLE
Drop development suffix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wfpc2tools
-version = 1.0.3.dev
+version = 1.0.4
 author = Warren Hack, Nadezhda Dencheva, David Grumm
 author-email = help@stsci.edu
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python


### PR DESCRIPTION
There was no way around this... I tagged `1.0.3` while `1.0.3.dev` was in place a long time ago.

This is partially aesthetic and partially to show this version as an actual release on pypi. 